### PR TITLE
Update best-of-update-action to v0.8.5

### DIFF
--- a/.github/workflows/update-list.yml
+++ b/.github/workflows/update-list.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: update-best-of-list
-        uses: best-of-lists/best-of-update-action@v0.7.3
+        uses: best-of-lists/best-of-update-action@v0.8.5
         with:
           libraries_key: ${{ secrets.LIBRARIES_KEY }}
           github_key: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit updates the best-of-update-action GitHub Action to the latest version (v0.8.5) in your workflow file.